### PR TITLE
avoid mask case crash on some phone.

### DIFF
--- a/cocos/renderer/gfx/DeviceGraphics.cpp
+++ b/cocos/renderer/gfx/DeviceGraphics.cpp
@@ -830,14 +830,11 @@ void DeviceGraphics::commitStencilStates()
 {
     if (_currentState->stencilTest != _nextState->stencilTest)
     {
-        if (!_nextState->stencilTest)
-        {
-            glDisable(GL_STENCIL_TEST);
-            return;
+        if (_nextState->stencilTest)
+		{
+            glEnable(GL_STENCIL_TEST);
         }
-        
-        glEnable(GL_STENCIL_TEST);
-        
+
         if (_nextState->stencilSeparation)
         {
             GL_CHECK(glStencilFuncSeparate(GL_FRONT,
@@ -869,7 +866,12 @@ void DeviceGraphics::commitStencilStates()
                         ENUM_CLASS_TO_GLENUM(_nextState->stencilZFailOpFront),
                         ENUM_CLASS_TO_GLENUM(_nextState->stencilZPassOpFront)));
         }
-        
+
+        if (!_nextState->stencilTest)
+		{
+            glDisable(GL_STENCIL_TEST);
+        }
+		
         return;
     }
     

--- a/cocos/renderer/gfx/DeviceGraphics.cpp
+++ b/cocos/renderer/gfx/DeviceGraphics.cpp
@@ -831,7 +831,7 @@ void DeviceGraphics::commitStencilStates()
     if (_currentState->stencilTest != _nextState->stencilTest)
     {
         if (_nextState->stencilTest)
-		{
+        {
             glEnable(GL_STENCIL_TEST);
         }
 
@@ -868,7 +868,7 @@ void DeviceGraphics::commitStencilStates()
         }
 
         if (!_nextState->stencilTest)
-		{
+        {
             glDisable(GL_STENCIL_TEST);
         }
 		


### PR DESCRIPTION
mobile:
Nubia NX659J

demo:
[test.zip](https://github.com/cocos-creator/engine-native/files/6775983/test.zip)

stack:
``` log
2021-07-07 17:19:49.680 3501-3567/org.cocos2d.demo A/libc: Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0xd in tid 3567 (GLThread 2118), pid 3501 (rg.cocos2d.demo)
2021-07-07 17:19:49.695 609-609/? E/SELinux: avc:  denied  { find } for pid=14078 uid=10108 name=tethering scontext=u:r:woodpecker_app:s0 tcontext=u:object_r:tethering_service:s0 tclass=service_manager permissive=0
2021-07-07 17:19:49.714 3629-3629/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
2021-07-07 17:19:49.714 3629-3629/? A/DEBUG: Build fingerprint: 'nubia/NX659J/NX659J:11/RKQ1.200826.002/nubia.20210222.122529:user/release-keys'
2021-07-07 17:19:49.714 3629-3629/? A/DEBUG: Revision: '0'
2021-07-07 17:19:49.714 3629-3629/? A/DEBUG: ABI: 'arm64'
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG: Timestamp: 2021-07-07 17:19:49+0800
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG: pid: 3501, tid: 3567, name: GLThread 2118  >>> org.cocos2d.demo <<<
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG: uid: 10233
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0xd
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG: Cause: null pointer dereference
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     x0  0000000000000003  x1  0000000000000000  x2  0000000000010124  x3  0000000000000000
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     x4  0000000000000001  x5  0000000000000004  x6  0000000000000001  x7  0000000000000001
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     x8  b4000076ce175dd8  x9  0000000000000000  x10 b4000076ce175dd8  x11 b4000076ce175dd8
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     x12 0000000000000003  x13 b4000076ce175db8  x14 b40000761e135b30  x15 0000000000000000
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     x16 0000000000000002  x17 0000000000000002  x18 000000755aa4c000  x19 0000000000000000
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     x20 b4000077ce13a040  x21 0000000000000001  x22 b40000770e138850  x23 b4000076ae141790
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     x24 0000000000000001  x25 0000000000000019  x26 b4000077ce13e0dc  x27 b4000077ce145c44
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     x28 0000000000000001  x29 000000755e1191a0
2021-07-07 17:19:49.715 3629-3629/? A/DEBUG:     lr  00000075ae450024  sp  000000755e119180  pc  00000075ae450390  pst 0000000060001000
2021-07-07 17:19:49.626 0-0/? E/====>>get lock_screen: 1<<====
2021-07-07 17:19:49.626 0-0/? E/====>>get hdmi_connect_on: 0<<====
2021-07-07 17:19:49.784 962-962/? E/CompositionEngine: map unknown (BT709 sRGB Full range)/(Unknown RenderIntent) to default color mode
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG: backtrace:
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #00 pc 0000000000373390  /vendor/lib64/egl/libGLESv2_adreno.so (BuildId: 30dfa5f69e60bd17a24b223c7277d81c)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #01 pc 0000000000161558  /vendor/lib64/egl/libGLESv2_adreno.so (BuildId: 30dfa5f69e60bd17a24b223c7277d81c)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #02 pc 00000000000ec13c  /vendor/lib64/egl/libGLESv2_adreno.so (BuildId: 30dfa5f69e60bd17a24b223c7277d81c)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #03 pc 000000000025a2e8  /vendor/lib64/egl/libGLESv2_adreno.so (BuildId: 30dfa5f69e60bd17a24b223c7277d81c)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #04 pc 000000000025d460  /vendor/lib64/egl/libGLESv2_adreno.so (BuildId: 30dfa5f69e60bd17a24b223c7277d81c)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #05 pc 0000000000245068  /vendor/lib64/egl/libGLESv2_adreno.so (BuildId: 30dfa5f69e60bd17a24b223c7277d81c)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #06 pc 000000000001fd34  /system/lib64/libEGL.so (android::eglSwapBuffersWithDamageKHRImpl(void*, void*, int*, int)+608) (BuildId: 07df33677759a75fb397191ef4b07e54)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #07 pc 000000000001c3a0  /system/lib64/libEGL.so (eglSwapBuffers+188) (BuildId: 07df33677759a75fb397191ef4b07e54)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #08 pc 00000000000a7410  /system/lib64/libandroid_runtime.so (android::jni_eglSwapBuffers(_JNIEnv*, _jobject*, _jobject*, _jobject*)+104) (BuildId: 8ac932734cd2c73af813eb1c5d6c4518)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #09 pc 0000000000210c84  /system/framework/arm64/boot-framework.oat (art_jni_trampoline+180) (BuildId: 5fd65e246a54f4cc956b9139e094cd821880cafd)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #10 pc 0000000000133564  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+548) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #11 pc 00000000001a8a94  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+228) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #12 pc 0000000000319ea0  /apex/com.android.art/lib64/libart.so (art::interpreter::ArtInterpreterToCompiledCodeBridge(art::Thread*, art::ArtMethod*, art::ShadowFrame*, unsigned short, art::JValue*)+376) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #13 pc 00000000003101cc  /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false, false>(art::ArtMethod*, art::Thread*, art::ShadowFrame&, art::Instruction const*, unsigned short, art::JValue*)+996) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #14 pc 000000000067ff10  /apex/com.android.art/lib64/libart.so (MterpInvokeInterface+1032) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #15 pc 000000000012da14  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_interface+20) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #16 pc 0000000000369e68  /system/framework/framework.jar (offset 0x922000) (android.opengl.GLSurfaceView$EglHelper.swap+12)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #17 pc 000000000067e7e0  /apex/com.android.art/lib64/libart.so (MterpInvokeVirtual+1520) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #18 pc 000000000012d814  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_virtual+20) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #19 pc 000000000036a81e  /system/framework/framework.jar (offset 0x922000) (android.opengl.GLSurfaceView$GLThread.guardedRun+1162)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #20 pc 0000000000680e5c  /apex/com.android.art/lib64/libart.so (MterpInvokeDirect+1248) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #21 pc 000000000012d914  /apex/com.android.art/lib64/libart.so (mterp_op_invoke_direct+20) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #22 pc 000000000036ade4  /system/framework/framework.jar (offset 0x922000) (android.opengl.GLSurfaceView$GLThread.run+48)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #23 pc 00000000003077c8  /apex/com.android.art/lib64/libart.so (art::interpreter::Execute(art::Thread*, art::CodeItemDataAccessor const&, art::ShadowFrame&, art::JValue, bool, bool) (.llvm.277433531913943662)+268) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #24 pc 000000000066d248  /apex/com.android.art/lib64/libart.so (artQuickToInterpreterBridge+780) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #25 pc 000000000013cff8  /apex/com.android.art/lib64/libart.so (art_quick_to_interpreter_bridge+88) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #26 pc 0000000000133564  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+548) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #27 pc 00000000001a8a94  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+228) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.794 3629-3629/? A/DEBUG:       #28 pc 0000000000556aa4  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithJValues<art::ArtMethod*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, art::ArtMethod*, jvalue const*)+460) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.795 3629-3629/? A/DEBUG:       #29 pc 00000000005a5e6c  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallback(void*)+1308) (BuildId: 47348f787714436601c7ea9c01a04b88)
2021-07-07 17:19:49.795 3629-3629/? A/DEBUG:       #30 pc 00000000000b0654  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+392) (BuildId: debd070a4a6282dee7237aed85e92299)
2021-07-07 17:19:49.795 3629-3629/? A/DEBUG:       #31 pc 0000000000050888  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: debd070a4a6282dee7237aed85e92299)
2021-07-07 17:19:49.795 962-962/? E/CompositionEngine: map unknown (BT709 sRGB Full range)/(Unknown RenderIntent) to default color mode
```