### PR TITLE
fix spine crash

### DIFF
--- a/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/cocos/bindings/jswrapper/v8/Object.cpp
@@ -475,8 +475,10 @@ void Object::clearPrivateData(bool clearMapping) {
         if (clearMapping) {
             NativePtrToObjectMap::erase(_privateData);
         }
-        internal::clearPrivate(__isolate, _obj);
-        setProperty("__native_ptr__", se::Value(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(nullptr))));
+        if (!_obj.persistent().IsEmpty()) {
+            internal::clearPrivate(__isolate, _obj);
+            setProperty("__native_ptr__", se::Value(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(nullptr))));
+        }
         _privateData = nullptr;
     }
 }

--- a/cocos/bindings/manual/jsb_spine_manual.cpp
+++ b/cocos/bindings/manual/jsb_spine_manual.cpp
@@ -234,13 +234,41 @@ bool register_all_spine_manual(se::Object *obj) {
 
     spine::setSpineObjectDisposeCallback([](void *spineObj) {
         // Support Native Spine fo Creator V3.0
+		se::Object *seObj = nullptr;
+
         auto iter = se::NativePtrToObjectMap::find(spineObj);
         if (iter != se::NativePtrToObjectMap::end()) {
+            // Save se::Object pointer for being used in cleanup method.
+            seObj = iter->second;
             // Unmap native and js object since native object was destroyed.
             // Otherwise, it may trigger 'assertion' in se::Object::setPrivateData later
             // since native obj is already released and the new native object may be assigned with
             // the same address.
             se::NativePtrToObjectMap::erase(iter);
+        } else {
+            return;
+        }
+
+        auto cleanup = [seObj]() {
+            auto se = se::ScriptEngine::getInstance();
+            if (!se->isValid() || se->isInCleanup())
+                return;
+
+            se::AutoHandleScope hs;
+            se->clearException();
+
+            // The mapping of native object & se::Object was cleared in above code.
+            // The private data (native object) may be a different object associated with other se::Object.
+            // Therefore, don't clear the mapping again.
+            seObj->clearPrivateData(false);
+            seObj->unroot();
+            seObj->decRef();
+        };
+
+        if (!se::ScriptEngine::getInstance()->isGarbageCollecting()) {
+            cleanup();
+        } else {
+            CleanupTask::pushTaskToAutoReleasePool(cleanup);
         }
     });
 


### PR DESCRIPTION
without call Object::clearPrivateData, the c++ object maybe bind to two JS object, when one was release, other one will  case crash.

Some existent crash stacks.

![企业微信截图_16461276994724](https://user-images.githubusercontent.com/8321365/156341437-74d1fb1c-7eae-43e9-9bdb-3846ebe6f11e.png)
![企业微信截图_16461323241416](https://user-images.githubusercontent.com/8321365/156341460-ddef4eca-2392-48ae-8480-ed78bb6355e0.png)
![企业微信截图_16461880675214](https://user-images.githubusercontent.com/8321365/156341483-a88be9aa-d6f8-4fc3-b2ad-f0d06ae06161.png)

