### PR TITLE
fix spine rendering confusion

### DIFF
--- a/cocos/editor-support/spine-creator-support/SkeletonCache.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonCache.cpp
@@ -322,7 +322,11 @@ namespace spine {
         auto& drawOrder = _skeleton->getDrawOrder();
         for (size_t i = 0, n = drawOrder.size(); i < n; ++i) {
             slot = drawOrder[i];
-            
+
+            if (slot->getBone().isActive() == false) {
+                continue;
+            }
+
             if (!slot->getAttachment()) {
                 _clipper->clipEnd(*slot);
                 continue;

--- a/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonRenderer.cpp
@@ -408,6 +408,11 @@ void SkeletonRenderer::render (float deltaTime) {
     for (size_t i = 0, n = drawOrder.size(); i < n; ++i) {
         isFull = 0;
         slot = drawOrder[i];
+
+        if (slot->getBone().isActive() == false) {
+            continue;
+        }
+
         if (_startSlotIndex >= 0 && _startSlotIndex == slot->getData().getIndex()) {
             inRange = true;
         }

--- a/cocos/editor-support/spine/Json.cpp
+++ b/cocos/editor-support/spine/Json.cpp
@@ -88,6 +88,8 @@ bool Json::getBoolean(spine::Json *value, const char *name, bool defaultValue) {
 	value = getItem(value, name);
 	if (value) {
 		if (value->_valueString) return strcmp(value->_valueString, "true") == 0;
+		if (value->_type == JSON_TRUE) return true;
+		if (value->_type == JSON_FALSE) return false;
 		if (value->_type == JSON_NULL) return false;
 		if (value->_type == JSON_NUMBER) return value->_valueFloat != 0;
 		return defaultValue;


### PR DESCRIPTION
Re: cocos/2d-tasks#3621

Changelog:
* Fix incorrect parsing of JSON boolean value.
* Skips rendering slots without active bones .